### PR TITLE
fix: update token owner on transfer

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -29,7 +29,6 @@ export function handleTransfer(event: TransferEvent): void {
 
   if (token == null) {
     token = new Token(event.params.tokenId.toHexString());
-    token.owner = event.params.to.toHexString();
     token.contract = event.address.toHexString();
 
     let uri = instance.try_tokenURI(event.params.tokenId);
@@ -37,6 +36,8 @@ export function handleTransfer(event: TransferEvent): void {
       token.uri = uri.value;
     }
   }
+
+  token.owner = event.params.to.toHexString();
 
   if (transfer == null) {
     transfer = new Transfer(transferId);


### PR DESCRIPTION
The previous implementation didn't update the token owner upon transfer
of tokens. This led to the subgraph returning the first owner for all
time for a given token